### PR TITLE
Added importPath to SupabaseStorageGetSignedUrl registration for codegen

### DIFF
--- a/src/components/SupabaseStorageGetSignedUrl/registerComponentMeta.tsx
+++ b/src/components/SupabaseStorageGetSignedUrl/registerComponentMeta.tsx
@@ -71,4 +71,5 @@ export const SupabaseStorageGetSignedUrlMeta: CodeComponentMeta<SupabaseStorageG
       argTypes: [],
     },
   },
+  importPath: "./index",
 }


### PR DESCRIPTION
Codegen registration failed without importPath parameter in the Plasmic Component Registration for SupabaseStorageGetSignedUrl,