### PR TITLE
Low code usermetadata registration & emailRedirect param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plasmic-supabase",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plasmic-supabase",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@plasmicapp/data-sources": "^0.1.143",

--- a/src/components/SupabaseStorageGetSignedUrl/registerComponentMeta.tsx
+++ b/src/components/SupabaseStorageGetSignedUrl/registerComponentMeta.tsx
@@ -71,4 +71,5 @@ export const SupabaseStorageGetSignedUrlMeta: CodeComponentMeta<SupabaseStorageG
       argTypes: [],
     },
   },
+  importPath: "./index",
 }

--- a/src/components/SupabaseUserGlobalContext/registerComponentMeta.tsx
+++ b/src/components/SupabaseUserGlobalContext/registerComponentMeta.tsx
@@ -40,8 +40,11 @@ export const SupabaseUserGlobalContextMeta : GlobalContextMeta<SupabaseUserGloba
           type: "string"
         },
         {
-          name: "options",
-          displayName: "Optional: options object eg {data: {age: 25}} (see https://bit.ly/sb-docs-signup)",
+          name: "emailRedirect",
+          type: "string"
+        },
+        {
+          name: "userMetadata",
           type: "object"
         }
       ],

--- a/src/components/SupabaseUserGlobalContext/registerComponentMeta.tsx
+++ b/src/components/SupabaseUserGlobalContext/registerComponentMeta.tsx
@@ -45,6 +45,7 @@ export const SupabaseUserGlobalContextMeta : GlobalContextMeta<SupabaseUserGloba
         },
         {
           name: "userMetadata",
+          displayName: "Custom user metadata (object with key:value pairs)",
           type: "object"
         }
       ],


### PR DESCRIPTION
### Implementation of issue #14 

**Challenge**: Users currently have to understand the shape of the `options` object to specify it via the Plasmic UI. The `options` object is a nested object. Plasmic doesn't allow specifying a description or hint in actions registration for GlobalContext like it does for regular code component registration. As such, developers find they have to refer to Supabase docs to determine its shape. It gets more complicated when adding other options like emailRedirect

```
options: {
    data: {
        first_name: 'John',
        age: 27
    },
    emailRedirectTo: 'https://example.com/welcome'
}
```

**Resolution**: The proposed approach:

- Simplifies the user experience in the Plasmic UI. The user only needs specify a one-dimensional object of key:value pairs.
  - The component builds the options object dynamically if metadata is set.
- Adds specific input argument to specify the email redirect URL (useful for redirecting a user to their previous point in an application flow after verification)

**Future improvement options**: 
- Plasmic allows specification of custom react components to manage input args for custom code components. If possible for global context components also, a custom object builder UI (similar to select component) could be added for a _nocode_ approach to specifying user metadata.