### PR TITLE
Resolved incorrect case in "containedBy" filter operator selection

### DIFF
--- a/src/components/SupabaseProvider/registerComponentMeta.tsx
+++ b/src/components/SupabaseProvider/registerComponentMeta.tsx
@@ -73,7 +73,7 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
                 label: "contains every element in (contains)"
               },
               {
-                value: "containedby",
+                value: "containedBy",
                 label: "contained by (containedby)"
               },
               {


### PR DESCRIPTION
Incorrect case in containedBy filter operator selection caused error in Supabase Data Provider. Updated "containedby" filter operator to "containedBy" to match registered types and Supabase documentation.