### PR TITLE
Custom schema

### DIFF
--- a/src/components/SupabaseProvider/index.tsx
+++ b/src/components/SupabaseProvider/index.tsx
@@ -32,7 +32,7 @@ interface Actions {
   addRow(rowForSupabase: any, optimisticRow: any): void;
   editRow(rowForSupabase: any, optimisticRow: any): void;
   flexibleMutation(
-    schema: string | undefined,  // Add schema parameter
+    schema: string | undefined,
     tableName: string,
     operation: "insert" | "update" | "delete" | "upsert",
     dataForSupabase: any,
@@ -41,7 +41,7 @@ interface Actions {
     optimisticData: any,
   ): void;
   runRpc(
-    schema: string | undefined,  // Add schema parameter
+    schema: string | undefined,
     rpcName: string,
     dataForSupabase: any,
     optimisticOperation: string | undefined,
@@ -171,7 +171,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
       shouldRetryOnError: false,
     });
 
-    //When filters, tablename, columns or disableFetchData changes, refetch data
+    //When filters, tablename, columns or disableFetchData, schemaName changes, refetch data
     useEffect(() => {
       console.log('refetching useffect');
       mutate().catch((err) => setMutationError(getErrMsg(err)));
@@ -385,7 +385,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
 
     const flexibleMutation = useCallback(
       async (
-        schema: string | undefined,  // Add schema parameter
+        schema: string | undefined,
         tableName: string,
         operation: "insert" | "update" | "delete" | "upsert",
         dataForSupabase: Row,
@@ -418,7 +418,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         //Build the flexible mutation
         const supabaseQuery = buildSupabaseQueryWithDynamicFilters({
           supabase,
-          schema: schema ?? schemaName, // Use provided schema or fall back to provider's schema
+          schema: schema ?? schemaName,
           tableName,
           operation,
           columns: null,

--- a/src/components/SupabaseProvider/index.tsx
+++ b/src/components/SupabaseProvider/index.tsx
@@ -32,6 +32,7 @@ interface Actions {
   addRow(rowForSupabase: any, optimisticRow: any): void;
   editRow(rowForSupabase: any, optimisticRow: any): void;
   flexibleMutation(
+    schema: string | undefined,  // Add schema parameter
     tableName: string,
     operation: "insert" | "update" | "delete" | "upsert",
     dataForSupabase: any,
@@ -40,6 +41,7 @@ interface Actions {
     optimisticData: any,
   ): void;
   runRpc(
+    schema: string | undefined,  // Add schema parameter
     rpcName: string,
     dataForSupabase: any,
     optimisticOperation: string | undefined,
@@ -68,6 +70,7 @@ export interface SupabaseProviderProps {
   initialSortField: string;
   initialSortDirection: "asc" | "desc";
   disableFetchData: boolean;
+  schema?: string;
 }
 
 //Define the Supabase provider component
@@ -95,7 +98,10 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
       initialSortField,
       initialSortDirection,
       disableFetchData,
+      schema
     } = props;
+
+    const schemaName: string = schema ?? 'public';
 
     //Setup state and memos
     const memoizedFilters = useDeepCompareMemo(() => filters, [filters]);
@@ -142,6 +148,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         columns,
         dataForSupabase: null,
         filters: memoizedFilters,
+        schema: schemaName,
       });
 
       //Execute the query
@@ -150,7 +157,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         throw error;
       }
       return data;
-    }, [tableName, columns, memoizedFilters, disableFetchData]);
+    }, [tableName, columns, memoizedFilters, disableFetchData, schemaName]);
 
     //Fetch data using SWR
     const {
@@ -168,7 +175,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
     useEffect(() => {
       console.log('refetching useffect');
       mutate().catch((err) => setMutationError(getErrMsg(err)));
-    }, [memoizedFilters, tableName, columns, disableFetchData, mutate]);
+    }, [memoizedFilters, tableName, columns, disableFetchData, schemaName, mutate]);
 
     //When data changes, set data
     //In turn this will cause change to sortedData
@@ -309,11 +316,11 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
 
         //Add the row to supabase
         const supabase = createClient();
-        const { error } = await supabase.from(tableName).insert(rowForSupabase);
+        const { error } = await supabase.schema(schemaName).from(tableName).insert(rowForSupabase);
         if (error) throw error;
         return optimisticFunc(data, optimisticRow);
       },
-      [data, generateRandomErrors, tableName]
+      [data, generateRandomErrors, tableName, schemaName]
     );
 
     //Function to actually update row in supabase
@@ -331,6 +338,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         //Update the row in supabase
         const supabase = createClient();
         const { error } = await supabase
+          .schema(schemaName)
           .from(tableName)
           .update(rowForSupabase)
           .eq(uniqueIdentifierField, rowForSupabase[uniqueIdentifierField]);
@@ -342,6 +350,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         generateRandomErrors,
         tableName,
         uniqueIdentifierField,
+        schemaName,
       ]
     );
 
@@ -356,6 +365,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         //Delete the row in supabase
         const supabase = createClient();
         const { error } = await supabase
+          .schema(schemaName)
           .from(tableName)
           .delete()
           .eq(uniqueIdentifierField, uniqueIdentifierVal);
@@ -369,11 +379,13 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         tableName,
         uniqueIdentifierField,
         deleteRowOptimistically,
+        schemaName,
       ]
     );
 
     const flexibleMutation = useCallback(
       async (
+        schema: string | undefined,  // Add schema parameter
         tableName: string,
         operation: "insert" | "update" | "delete" | "upsert",
         dataForSupabase: Row,
@@ -406,6 +418,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         //Build the flexible mutation
         const supabaseQuery = buildSupabaseQueryWithDynamicFilters({
           supabase,
+          schema: schema ?? schemaName, // Use provided schema or fall back to provider's schema
           tableName,
           operation,
           columns: null,
@@ -419,12 +432,13 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
 
         return optimisticFunc(data, optimisticData);
       },
-      [data, generateRandomErrors]
+      [data, generateRandomErrors, schemaName]
     )
 
     //Function to run an RPC (database function) in supabase
     const rpc = useCallback(
       async (
+        schema: string | undefined,  // Add schema parameter
         rpcName: string,
         dataForSupabase: any,
         optimisticData: any,
@@ -439,12 +453,12 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
         const supabase = createClient();
         //Typescript ignore next line because it's a dynamic function call that typescript doesn't know available options for
         // @ts-ignore
-        const { error } = await supabase.rpc(rpcName, dataForSupabase);
+        const { error } = await supabase.schema(schema ?? schemaName).rpc(rpcName, dataForSupabase);
         if (error) throw error;
 
         return optimisticFunc(data, optimisticData);
       },
-      [data, generateRandomErrors]
+      [data, generateRandomErrors, schemaName]
     );
 
     //Helper function to choose the correct optimistic data function to run
@@ -538,6 +552,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
       //Element action to run a flexible mutation with optimistic operation (addRow, editRow, deleteRow, replaceData or none)
       //and auto-refetch when done
       flexibleMutation: async (
+        schema,
         tableName,
         operation,
         dataForSupabase,
@@ -555,7 +570,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
 
         //Run the operation with optimistically updated data
         //if optimisticOperation is not specified, the optimisticFunc will be returnUnchangedData, disabling optimistic update
-        mutate(flexibleMutation(tableName, operation, dataForSupabase, filters, optimisticData, optimisticFunc), {
+        mutate(flexibleMutation(schema, tableName, operation, dataForSupabase, filters, optimisticData, optimisticFunc), {
           populateCache: true,
           optimisticData: optimisticFunc(data, optimisticData),
         }).catch((err) => setMutationError(getErrMsg(err)));
@@ -564,6 +579,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
       //Element action to run a supabase RPC (database function) with optimistic operation (addRow, editRow, deleteRow, replaceData or none)
       //and auto-refetch when done
       runRpc: async (
+        schema,
         rpcName,
         dataForSupabase,
         optimisticOperation,
@@ -579,7 +595,7 @@ export const SupabaseProvider = forwardRef<Actions, SupabaseProviderProps>(
 
         //Run the operation with optimistically updated data
         //if optimisticOperation is not specified, the optimisticFunc will be returnUnchangedData, disabling optimistic update
-        mutate(rpc(rpcName, dataForSupabase, optimisticData, optimisticFunc), {
+        mutate(rpc(schema, rpcName, dataForSupabase, optimisticData, optimisticFunc), {
           populateCache: true,
           optimisticData: optimisticFunc(data, optimisticData),
         }).catch((err) => setMutationError(getErrMsg(err)));

--- a/src/components/SupabaseProvider/registerComponentMeta.tsx
+++ b/src/components/SupabaseProvider/registerComponentMeta.tsx
@@ -11,6 +11,13 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
       type: "string",
       required: true,
     },
+    schema: {
+      type: "string",
+      required: false,
+      defaultValue: "public",
+      advanced: true,
+      description: "Optional, overrides public schema"
+    },
     tableName: {
       type: "string",
       required: true,
@@ -239,6 +246,7 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
     flexibleMutation: {
       description: "perform a flexible mutation",
       argTypes: [
+        { name: "schema", type: "string", displayName: "Schema (Optional, overrides public schema)" },
         { name: "tableName", type: "string", displayName: "Table name (to run mutation on)"},
         { name: "operation", type: "string", displayName: "Operation (insert / update / upsert / delete)" },
         { name: "dataForSupabase", type: "object", displayName: "Data for Supabase API call (leave blank for delete)" },
@@ -258,6 +266,7 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
     runRpc: {
       description: 'RPC for add row',
       argTypes: [
+        { name: "schema", type: "string", displayName: "Schema (Optional, overrides public schema)" }, // Add schema parameter
         { name: "rpcName", displayName: 'Name of the RPC', type: "string" },
         { name: "dataForSupabase", displayName: 'Data for Supabase API call', type: "object"},
         { 

--- a/src/components/SupabaseProvider/registerComponentMeta.tsx
+++ b/src/components/SupabaseProvider/registerComponentMeta.tsx
@@ -246,7 +246,7 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
     flexibleMutation: {
       description: "perform a flexible mutation",
       argTypes: [
-        { name: "schema", type: "string", displayName: "Schema (Optional, overrides public schema)" },
+        { name: "schema", type: "string", displayName: "Schema (Optional, overrides provider schema)" },
         { name: "tableName", type: "string", displayName: "Table name (to run mutation on)"},
         { name: "operation", type: "string", displayName: "Operation (insert / update / upsert / delete)" },
         { name: "dataForSupabase", type: "object", displayName: "Data for Supabase API call (leave blank for delete)" },
@@ -266,7 +266,7 @@ export const SupabaseProviderMeta : CodeComponentMeta<SupabaseProviderProps> = {
     runRpc: {
       description: 'RPC for add row',
       argTypes: [
-        { name: "schema", type: "string", displayName: "Schema (Optional, overrides public schema)" }, // Add schema parameter
+        { name: "schema", type: "string", displayName: "Schema (Optional, overrides provider schema)" },
         { name: "rpcName", displayName: 'Name of the RPC', type: "string" },
         { name: "dataForSupabase", displayName: 'Data for Supabase API call', type: "object"},
         { 

--- a/src/utils/buildSupabaseQueryWithDynamicFilters.ts
+++ b/src/utils/buildSupabaseQueryWithDynamicFilters.ts
@@ -23,6 +23,7 @@ export type BuildSupabaseQueryWithDynamicFiltersProps = {
   columns: string | null | undefined;
   dataForSupabase: any;
   filters: Filter[] | undefined;
+  schema: string;
 };
 
 const buildSupabaseQueryWithDynamicFilters = ({
@@ -32,24 +33,25 @@ const buildSupabaseQueryWithDynamicFilters = ({
   columns,
   dataForSupabase,
   filters,
+  schema
 } : BuildSupabaseQueryWithDynamicFiltersProps) => {
   //Build the query with dynamic filters passed as props to the component
   //The basic query
   let supabaseQuery;
   if(operation === "select" ){
     if(!columns) throw new Error("Error in buildSupabaseQueryWithDynamicFilters: columns must be a string like '*' or 'id, name' for select operation.");
-    supabaseQuery = supabase.from(tableName).select(columns);
+    supabaseQuery = supabase.schema(schema).from(tableName).select(columns);
   } else if (operation === "insert") {
     if(!dataForSupabase) throw new Error("Error in buildSupabaseQueryWithDynamicFilters: dataForSupabase must be an object with key-value pairs for insert operation.");
-    supabaseQuery = supabase.from(tableName).insert(dataForSupabase);
+    supabaseQuery = supabase.schema(schema).from(tableName).insert(dataForSupabase);
   } else if (operation === "update") {
     if(!dataForSupabase) throw new Error("Error in buildSupabaseQueryWithDynamicFilters: dataForSupabase must be an object with key-value pairs for update operation.");
-    supabaseQuery = supabase.from(tableName).update(dataForSupabase);
+    supabaseQuery = supabase.schema(schema).from(tableName).update(dataForSupabase);
   } else if (operation === "upsert") {
     if(!dataForSupabase) throw new Error("Error in buildSupabaseQueryWithDynamicFilters: dataForSupabase must be an object with key-value pairs for upsert operation.");
-    supabaseQuery = supabase.from(tableName).upsert(dataForSupabase);
+    supabaseQuery = supabase.schema(schema).from(tableName).upsert(dataForSupabase);
   } else if (operation === "delete") {
-    supabaseQuery = supabase.from(tableName).delete();
+    supabaseQuery = supabase.schema(schema).from(tableName).delete();
   } else {
     throw new Error("Error in buildSupabaseQueryWithDynamicFilters: Invalid operation. Must be select, insert, update, upsert, or delete.");
   }


### PR DESCRIPTION
You are my first contribution to GitHub. I have been here for many years but never learned to code. I thought it was time to get started. 

Overview

1. SupabaseProvider/index.tsx 
✓ Added schema prop 
✓ Handled schema in all actions 
✓ Set default schema fallback 
✓ Passed schema to queries and mutations

2. buildSupabaseQueryWithDynamicFilters.ts 
✓ Added schema to props type 
✓ Passed schema to Supabase client calls 
✓ Skipped validation (using Supabase's built-in validation)

3 . registerComponentMeta.tsx 
✓ Added schema prop in provider (fetchData) 
✓ Added schema prop in flexible mutations 
✓ Added schema prop in RPC

Issues
* Schema Use in Flexible Mutations and RPC
    * Schema override from the provider works, but deleting/unsetting the override in flexible mutations breaks functionality. The schema override can't be left blank after deleting or unsetting it, even when the correct schema is selected in the fetch provider.
 
* Sorting
    * Sorting worked once but couldn't replicate the functionality afterward.

To Do
* Better Error Handling in Flexible Mutations
    * Adding a non-existent table in the schema throws a generic error: "An unknown error occurred."
       Improve this by specifying: "The requested table does not exist within the specified schema."

It should work similarly to error handling in fetchData/queryProvider.